### PR TITLE
Remove redundant h2s

### DIFF
--- a/initial-configuration.md
+++ b/initial-configuration.md
@@ -6,8 +6,6 @@ menu:
     weight: 1
 ---
 
-## Initial Configuration
-
 To get started with ScaleFT, once you have an invite code:
 
 1. Create a Team in the ScaleFT platform, configuring an authentication method for all Team members.

--- a/teams.md
+++ b/teams.md
@@ -6,8 +6,6 @@ menu:
     weight: 2
 ---
 
-## Creating a Team
-
 A Team is a group of people who work together on infrastructure and share an authentication method (such as OAuth). Currently, creating a Team requires a ScaleFT Beta Invitation.
 
 When you create a Team, by default you are given Team Administrator permissions. By default, any additional Team members will belong only to the `everyone` Group, which grants certain view-only permissions. Additional permissions, such as SSH access, must be granted by you or another Team Administrator.


### PR DESCRIPTION
Remove h2s from the top of docs where the `meta.title` is the same text as the h2, leading to repetition like you see here: https://www.scaleft.com/docs/initial-configuration/