### PR TITLE
Updating sft debug env variable

### DIFF
--- a/sftd.md
+++ b/sftd.md
@@ -67,5 +67,5 @@ InitialURL: https://scaleft.example.com
 
 `sftd` reads the following variables when starting:
 
-  * `SCALEFT_DEBUG`:
+  * `SFT_DEBUG`:
     Prints additional debugging to `stderr` when set.


### PR DESCRIPTION
We've found in using the tools that it's SFT_DEBUG as opposed to SCALEFT_DEBUG.