### PR TITLE
Introduction changes (move concepts to their own page)

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -1,0 +1,44 @@
+---
+title: "Concepts"
+menu:
+  main:
+    parent: 'reference'
+    weight: 0
+---
+
+### Team
+
+
+A Team is a group of people who work together on infrastructure and share an authentication method (such as OAuth).
+
+[Team documentation]({{% relref "teams.md" %}})
+
+
+### Project
+
+A Project is a collection of resources (such as servers, load-balancers, web services, or VPNs) that share configurations and associated User Group permissions.
+
+[Project documentation]({{% relref "projects.md" %}})
+
+
+### Group
+
+A Group is a collection of Users and Team permissions. Groups are linked to Projects to describe Users' permissions within that Project.
+
+[Group documentation]({{% relref "groups.md" %}})
+
+
+### User
+
+A User is a member of a Team. Users can belong to multiple Groups and have multiple Clients.
+
+### Client
+
+The ScaleFT Client is installed on a device (such as a laptop or workstation) which a User uses to access infrastructure. The ScaleFT Client manages the dynamic credentials on the device so the User can transparently access ScaleFT-managed infrastructure.
+
+[Client Enrollment documentation]({{% relref "enrolling-a-client.md" %}})
+
+
+### Identity Provider (IdP)
+
+Every Team has an Identity Provider which Users authenticate to using the Team's authentication method. The IdP is the source of truth for User's identity and current access.

--- a/initial-configuration.md
+++ b/initial-configuration.md
@@ -13,6 +13,6 @@ To get started with ScaleFT:
 3. Install the ScaleFT server daemon (`sftd`) on one or more servers, and [enroll those servers]({{% relref "enrolling-a-server.md" %}}) in your Project.
 4. Have Team members install the ScaleFT Client and [enroll their Clients]({{% relref "enrolling-a-client.md" %}}) in your Team.
 
-The ScaleFT Daemon (sftd) will automatically configure your servers to trust certificates issued by the ScaleFT Platform as a method to authenticate SSH users. You can also configure `sftd` to create user accounts for the members of your Team, and even manage `sudo` access with ScaleFT roles and permissions.
+The ScaleFT Daemon (`sftd`) will automatically configure your servers to trust certificates issued by the ScaleFT Platform as a method to authenticate SSH users. You can also configure `sftd` to create user accounts for the members of your Team, and even manage `sudo` access with ScaleFT roles and permissions.
 
 Once installed by the members of your Team, The ScaleFT Client will connect to the ScaleFT Platform to verify Users against your Identity Provider (IdP). While a team member remains authenticated, the Client manages the dynamic credentials that enable that User to authenticate to any resources they may access.

--- a/introduction.md
+++ b/introduction.md
@@ -10,32 +10,6 @@ menu:
 
 ScaleFT is a cloud-native security platform that brings risk-based, dynamic authentication to cloud infrastructure using short-lived certificates.
 
-## Concepts
-
-### Team
-
-A Team is a group of people who work together on infrastructure and share an authentication method (such as OAuth).
-
-### Project
-
-A Project is a collection of resources (such as servers, load-balancers, web services, or VPNs) that share configurations and associated User Group permissions.
-
-### Group
-
-A Group is a collection of Users and Team permissions. Groups are linked to Projects to describe Users' permissions within that Project.
-
-### User
-
-A User is a member of a Team. Users can belong to multiple Groups and have multiple Clients.
-
-### Client
-
-The ScaleFT Client is installed on a device (such as a laptop or workstation) which a User uses to access infrastructure. The ScaleFT Client manages the dynamic credentials on the device so the User can transparently access ScaleFT-managed infrastructure.
-
-### Identity Provider (IdP)
-
-Every Team has an Identity Provider which Users authenticate to using the Team's authentication method. The IdP is the source of truth for User's identity and current access.
-
 ## Architecture
 
 ScaleFT is composed of three components:


### PR DESCRIPTION
Right now when people visit https://www.scaleft.com/docs/ and click on "get started", they're taken to a sort of glossary of concepts. This was pretty confusing to me, so I moved the concepts to their own page  (under Reference) and added links to the relevant docs for each concept.

With this change, users are shown a basic overview of ScaleFT's architecture and reason for existing, concluding with a link to the initial configuration page. This arrangement seems less confusing to me.
