### PR TITLE
Rework setup docs on groups

### DIFF
--- a/groups.md
+++ b/groups.md
@@ -4,8 +4,6 @@ menu:
   main:
     parent: 'none'
     weight: 3
-aliases:
-  - /docs/groups
 ---
 
 ## Groups

--- a/groups.md
+++ b/groups.md
@@ -1,0 +1,86 @@
+---
+title: "Groups"
+menu:
+  main:
+    parent: 'none'
+    weight: 3
+aliases:
+  - /docs/groups
+---
+
+## Groups
+
+ScaleFT uses groups to make it easy to grant permissions to collections of related
+users. Every ScaleFT team comes with two pre-configured groups:
+
+1. `everyone` - contains every User on your ScaleFT Team.
+2. `owners` - initially contains the User who created the ScaleFT Team, but any Team
+   administrator can add or remove Users.
+
+Team Administrators (Users who have the `access_admin` role granted by at least
+one Group) can create additional groups granting any combination of roles.
+
+## Permissions
+
+The permissions of a ScaleFT User are determined by their memberships in Groups.
+There are two types of permissions:
+
+1. Team-wide roles
+2. Project memberships
+
+### Team-Wide Roles
+
+Each Group can have Team-wide roles affiliated with it.
+
+There are currently two roles supported by ScaleFT:
+
+1. Access User (`access_user`) - Users with this role may use ScaleFT Access to
+   access servers.
+2. Access Admin (`access_admin`) - Users with this role ("team administrators")
+   have full administrative permissions within their Team.
+
+### Project Membership
+
+In order to access a resource in a Project, a ScaleFT User must be a member of
+a Group that has been linked to that Project.
+
+A Group's relationship to a Project has two configurations:
+
+1. `server_access`: members of this Group may access servers in this project.
+2. `server_admin`: members of this Group will receive administrative (e.g. sudo)
+   permissions on servers in this project.
+
+Because these are parameters of the Group's membership in a Project, and not
+properties of the Group itself, it is possible for a single Group to grant
+different levels of access to different Projects (for example, your "Intern"
+Group might have `sudo` permissions on servers in the "Intern" Project, but only
+login permissions on servers in the "Production" Project).
+
+Group permissions are additive within a Project. Users who are a member of a
+Project via more than one Group will receive permissions equivalent to those implied
+by their most permissive membership.
+
+For example, if a user is a member of groups `A` and `B`, and group `A` grants
+only `server_access` on project `P`, but group `B` grants both `server_access`
+and `server_admin` on project `P`, the user will receive both `server_access`
+and `server_admin`.
+
+## Quick Start
+
+In order for a User to SSH to a server using ScaleFT:
+
+1. The User must be a member of a Group.
+2. That Group must be linked to the Project which contains the server, and
+   the Group must at least have the `server_access` flag set for that Project.
+
+The simplest way to get up and running with access to your server is to:
+
+1. Browse to your Project in the ScaleFT Dashboard.
+2. Click "Link Group" from the "Permissions" tab.
+3. Enter `everyone` as the name of the Group. This will grant access to every
+   user on your ScaleFT Team.
+4. Check the `server_access` checkbox in order to grant the Users access to the
+   servers in your Project.
+5. Optionally check the `server_admin` box in order to grant the Users
+   administrative (i.e. sudo) permissions on servers in your Project.
+6. Click "Submit" to link the `everyone` Group to your Project.

--- a/groups.md
+++ b/groups.md
@@ -6,8 +6,6 @@ menu:
     weight: 3
 ---
 
-## Groups
-
 ScaleFT uses groups to make it easy to grant permissions to collections of related
 users. Every ScaleFT team comes with two pre-configured groups:
 

--- a/setup/groups.md
+++ b/setup/groups.md
@@ -1,89 +1,36 @@
 ---
-title: "Granting Access"
+title: "Creating a Group"
 menu:
   main:
     parent: 'setup'
-    weight: 4
-aliases:
-  - /docs/groups
+    weight: 3
 ---
 
-## Groups
+ScaleFT uses Groups to make it easy to grant permissions to collections of related
+users. Every ScaleFT Team comes with two default groups:
 
-A Group is a collection of Users who have the same permissions.
-Every ScaleFT team comes with two pre-configured groups:
+1. `everyone` - every User on your ScaleFT Team is automatically a member.
+2. `owners` - initially only the User who created the ScaleFT Team is a member,
+   but any Team administrator can add or remove Users.
 
-1. `everyone` - contains every User on your ScaleFT Team. By default it grants
-   only the `access_user` role, but Team Administrators can change what roles
-   are granted by this group.
-2. `owners` - grants both `access_user` and `access_admin` roles. By default it
-   contains only the User who initially created the ScaleFT Team, but any Team
-   administrator can add or remove Users.
+If you want one of the default Groups to have access to your servers, skip ahead
+to [creating a Project]({{% relref "projects.md"%}}).
 
-Team Administrators (Users who have the `access_admin` role granted by at least
-one Group) can create additional groups granting any combination of roles.
+To create a new group, click "Groups" in navigation panel, then click "New Group".
 
-## Permissions
+### Naming a Group
 
-The permissions of a ScaleFT User are determined by their memberships in Groups.
-There are two types of permissions:
+Choose a unique name to identify your Group. It may not contain spaces or special
+characters other than `-`, `_`, or `.`.
 
-1. Team-wide roles
-2. Project memberships
+### Team Roles
 
-### Team-Wide Roles
+Each Group can have Team-wide roles affiliated with it. Currently the only role
+available is Admin, which grants members of a group full administrative privileges
+on your team. If you want your new group to have these privileges select the "Admin"
+role.
 
-Each Group can have Team-wide roles affiliated with it.
+### Group Members
 
-There are currently two roles supported by ScaleFT:
-
-1. Access User (`access_user`) - Users with this role may use ScaleFT Access to
-   access servers.
-2. Access Admin (`access_admin`) - Users with this role ("team administrators")
-   have full administrative permissions within their Team.
-
-### Project Membership
-
-In order to access a resource in a Project, a ScaleFT User must be a member of
-a Group that has been linked to that Project.
-
-A Group's relationship to a Project has two configurations:
-
-1. `server_access`: members of this Group may access servers in this project.
-2. `server_admin`: members of this Group will receive administrative (e.g. sudo)
-   permissions on servers in this project.
-
-Because these are parameters of the Group's membership in a Project, and not
-properties of the Group itself, it is possible for a single Group to grant
-different levels of access to different Projects (for example, your "Intern"
-Group might have `sudo` permissions on servers in the "Intern" Project, but only
-login permissions on servers in the "Production" Project).
-
-Group permissions are additive within a Project. Users who are a member of a
-Project via more than one Group will receive permissions equivalent to those implied
-by their most permissive membership.
-
-For example, if a user is a member of groups `A` and `B`, and group `A` grants
-only `server_access` on project `P`, but group `B` grants both `server_access`
-and `server_admin` on project `P`, the user will receive both `server_access`
-and `server_admin`.
-
-## Quick Start
-
-In order for a User to SSH to a server using ScaleFT:
-
-1. The User must be a member of a Group.
-2. That Group must be linked to the Project which contains the server, and
-   the Group must at least have the `server_access` flag set for that Project.
-
-The simplest way to get up and running with access to your server is to:
-
-1. Browse to your Project in the ScaleFT Dashboard.
-2. Click "Link Group" from the "Permissions" tab.
-3. Enter `everyone` as the name of the Group. This will grant access to every
-   user on your ScaleFT Team.
-4. Check the `server_access` checkbox in order to grant the Users access to the
-   servers in your Project.
-5. Optionally check the `server_admin` box in order to grant the Users
-   administrative (i.e. sudo) permissions on servers in your Project.
-6. Click "Submit" to link the `everyone` Group to your Project.
+Once you've created the group you can add any members you wish. You can always remove
+members from a group later.

--- a/setup/projects.md
+++ b/setup/projects.md
@@ -3,28 +3,29 @@ title: "Creating a Project"
 menu:
   main:
     parent: 'setup'
-    weight: 3
+    weight: 4
 aliases:
   - /docs/projects
 ---
 
-A Project is a collection of resources (such as servers, load-balancers, web services, or VPNs) that share configurations and associated User Group permissions.
+ScaleFT user projects to organize collections of servers that are accessible by
+one or more Groups of users. In order for users to authenticate to a server, the
+server will need to belong to a Project and the user will need to be a member of
+a Group that has permission access servers in that Project.
 
-## Naming a Project
+To create a project, click "Projects" in the nagivation panel, then click "New Project".
+
+### Naming a Project
 
 Choose a unique name to identify your project. It may not contain spaces or special
 characters other than `-`, `_`, or `.`.
 
-## Configuration Options
-
 ### Create Server Users
 
-ScaleFT can optionally instruct `sftd` to create user accounts for users
-who are authorized to access a server. When operating in this mode:
+ScaleFT can optionally instruct `sftd` to create local user accounts on your servers
+for users who have access to the prject. When operating in this mode:
 
-1. Users will automatically be assigned a user name based on their ScaleFT user
-   name. Each ScaleFT user will have the same user name across all Projects in
-   their team.
+1. Users will automatically be assigned a user name based on their ScaleFT user name.
 2. On Linux servers, Users will be automatically assigned a UID starting from
    `60001` in the order that they are granted access to the project. UIDs are
    assigned by ScaleFT on a per-Project basis, so a user may have a different
@@ -32,3 +33,24 @@ who are authorized to access a server. When operating in this mode:
 
 To enable User Account creation for a project, check the `Create Server
 Users` box when creating the project.
+
+### Adding Groups
+
+Once you have created your project click on the "Permissions" tab, then click "Add Group"
+in order to grant a Group of users permission to log in to servers in the project.
+
+#### Server Account Permissions
+
+If your project is configured to create server accounts, ScaleFT will create an account
+for each member of a Group that you add to the project. You can control the permissions
+of these accounts when you add the Group to the Project.
+
+Choose "Admin" under Server Account Permissions if you want server accounts created
+by ScaleFT to have the abililty to use `sudo` on Linux, or Administrator privileges
+on Windows. Otherwise use "User", which will grant users the
+
+### Viewing Server Accounts
+
+If your project is configured to create server accounts for users, you can view
+a list of accounts that `sftd` will create on servers under the "Permissions"
+tab.


### PR DESCRIPTION
Simplify and update the group-related documentation in the setup flow:

1. Rename "Granting Access" to "Creating a Group", and simplify the content
2. Move "Creating a Group" before "Creating a Project"
3. Update the "Creating a Project" document to  include adding a group to the project

This also adds a copy of the original groups.md to the root of the repo, hidden from navigation, for later repurposing into a reference article. I'm happy to delete it and rely on git history if that seems more reasonable.