### PR TITLE
Add usage blurb at the bottom of redhat and ubuntu sft pages.

### DIFF
--- a/sft-redhat.md
+++ b/sft-redhat.md
@@ -23,3 +23,9 @@ Then, install the `scaleft-client-tools` package:
 ```
 sudo yum install scaleft-client-tools
 ```
+
+After installing, be sure to [enroll your client]({{% relref "enrolling-a-client.md" %}}).
+
+## Usage
+
+Once your client is enrolled, you can `ssh` to your servers with `sft ssh [hostname]`. For more details, see [SSHing to a Server]({{% relref "ssh.md" %}}).

--- a/sft-ubuntu.md
+++ b/sft-ubuntu.md
@@ -45,3 +45,9 @@ Unpacking scaleft-client-tools (0.18.6) ...
 Setting up scaleft-client-tools (0.18.6) ...
 robert_chiniquy@ubuntu:~$</div>
 {{% /terminal %}}
+
+After installing, be sure to [enroll your client]({{% relref "enrolling-a-client.md" %}}).
+
+## Usage
+
+Once your client is enrolled, you can `ssh` to your servers with `sft ssh [hostname]`. For more details, see [SSHing to a Server]({{% relref "ssh.md" %}}).


### PR DESCRIPTION
Copy-pasted because hugo can't seem to include markdown templates.